### PR TITLE
Add HTTP response log calls

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -35,7 +35,8 @@ func TryJsonify(object interface{}) interface{} {
 // extractHttpResponseElements is an indirection for if it is ever needed to add more elements.
 func extractHttpResponseElements(resp *http.Response) []logKeyValuePair {
 	return []logKeyValuePair{
-		makePair("responseHeaders", TryJsonify(resp.Header)),
+		makePair("responseContentType", resp.Header.Get("content-type")),
+		makePair("responseContentLength", resp.Header.Get("content-length")),
 		makePair("responseStatus", resp.Status),
 		makePair("requestUrl", resp.Request.URL.String()),
 	}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,0 +1,41 @@
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// LogKeyValuePair is a helper struct to help organise the use of tflog. tflog
+// uses pairs to print key-value items/args, so this just to help visualize the
+// way the logging works
+type LogKeyValuePair struct {
+	// Key is what will appear next to the value, use it as a small hint/description
+	Key string
+	// The value is what you want to log.
+	Value interface{}
+}
+
+func MakePair(key string, value interface{}) LogKeyValuePair {
+	return LogKeyValuePair{
+		Key:   key,
+		Value: value,
+	}
+}
+
+func AttachHttpResponse(ctx context.Context, resp *http.Response) context.Context {
+	// Makes it more usable than a map
+	jsonResponseHeaders, _ := json.Marshal(resp.Header)
+
+	respHeaders := MakePair("responseHeaders", jsonResponseHeaders)
+	respStatus := MakePair("responseStatus", resp.Status)
+	reqUrl := MakePair("requestUrl", resp.Request.URL)
+	pairs := []LogKeyValuePair{reqUrl, respStatus, respHeaders}
+
+	for _, pair := range pairs {
+		ctx = tflog.With(ctx, pair.Key, pair.Value)
+	}
+	return ctx
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -8,34 +8,59 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-// LogKeyValuePair is a helper struct to help organise the use of tflog. tflog
+// logKeyValuePair is a helper struct to help organise the use of tflog. tflog
 // uses pairs to print key-value items/args, so this just to help visualize the
 // way the logging works
-type LogKeyValuePair struct {
-	// Key is what will appear next to the value, use it as a small hint/description
+type logKeyValuePair struct {
+	// Key is what will appear next to the value, e.g. keyID=...
 	Key string
-	// The value is what you want to log.
+	// The value is what you want to log. e.g. Key=Value
 	Value interface{}
 }
 
-func MakePair(key string, value interface{}) LogKeyValuePair {
-	return LogKeyValuePair{
+func makePair(key string, value interface{}) logKeyValuePair {
+	return logKeyValuePair{
 		Key:   key,
 		Value: value,
 	}
 }
 
-func AttachHttpResponse(ctx context.Context, resp *http.Response) context.Context {
-	// Makes it more usable than a map
-	jsonResponseHeaders, _ := json.Marshal(resp.Header)
+// TryJsonify tries to marshall the object into a json string.
+// If a failure should occur, it will return the untouched object.
+func TryJsonify(object interface{}) interface{} {
+	jsonObject, err := json.Marshal(object)
+	if err == nil {
+		return string(jsonObject)
+	}
+	return object
+}
 
-	respHeaders := MakePair("responseHeaders", jsonResponseHeaders)
-	respStatus := MakePair("responseStatus", resp.Status)
-	reqUrl := MakePair("requestUrl", resp.Request.URL)
-	pairs := []LogKeyValuePair{reqUrl, respStatus, respHeaders}
+func AttachHttpResponse(ctx context.Context, resp *http.Response) context.Context {
+	// Makes resp.Header (a bit) more usable than a map
+	respHeaders := makePair("responseHeaders", TryJsonify(resp.Header))
+	respStatus := makePair("responseStatus", resp.Status)
+	reqUrl := makePair("requestUrl", resp.Request.URL.String())
+	pairs := []logKeyValuePair{reqUrl, respStatus, respHeaders}
 
 	for _, pair := range pairs {
 		ctx = tflog.With(ctx, pair.Key, pair.Value)
 	}
 	return ctx
+}
+
+func extractHttpResponseElements(resp *http.Response) []logKeyValuePair {
+	return []logKeyValuePair{
+		makePair("responseHeaders", TryJsonify(resp.Header)),
+		makePair("responseStatus", resp.Status),
+		makePair("requestUrl", resp.Request.URL.String()),
+	}
+}
+
+func ExtractHttpResponse(resp *http.Response) []interface{} {
+	elements := extractHttpResponseElements(resp)
+	args := make([]interface{}, 2*len(elements))
+	for _, pair := range elements {
+		args = append(args, pair.Key, pair.Value)
+	}
+	return args
 }

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -6,7 +6,7 @@ import (
 )
 
 // logKeyValuePair is a helper struct to help organise the use of tflog. tflog
-// uses pairs to print key-value items/args, so this just to help visualize the
+// uses pairs to print key-value items/args, so this is just to help visualize the
 // way the logging works
 type logKeyValuePair struct {
 	// Key is what will appear next to the value, e.g. keyID=...

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,11 +1,8 @@
 package logging
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
-
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 // logKeyValuePair is a helper struct to help organise the use of tflog. tflog
@@ -35,19 +32,7 @@ func TryJsonify(object interface{}) interface{} {
 	return object
 }
 
-func AttachHttpResponse(ctx context.Context, resp *http.Response) context.Context {
-	// Makes resp.Header (a bit) more usable than a map
-	respHeaders := makePair("responseHeaders", TryJsonify(resp.Header))
-	respStatus := makePair("responseStatus", resp.Status)
-	reqUrl := makePair("requestUrl", resp.Request.URL.String())
-	pairs := []logKeyValuePair{reqUrl, respStatus, respHeaders}
-
-	for _, pair := range pairs {
-		ctx = tflog.With(ctx, pair.Key, pair.Value)
-	}
-	return ctx
-}
-
+// extractHttpResponseElements is an indirection for if it is ever needed to add more elements.
 func extractHttpResponseElements(resp *http.Response) []logKeyValuePair {
 	return []logKeyValuePair{
 		makePair("responseHeaders", TryJsonify(resp.Header)),
@@ -56,9 +41,11 @@ func extractHttpResponseElements(resp *http.Response) []logKeyValuePair {
 	}
 }
 
+// ExtractHttpResponse extracts key-value pairs from the http.Response object.
+// This is to match the args signature of the tflog package.
 func ExtractHttpResponse(resp *http.Response) []interface{} {
 	elements := extractHttpResponseElements(resp)
-	args := make([]interface{}, 2*len(elements))
+	args := []interface{}{}
 	for _, pair := range elements {
 		args = append(args, pair.Key, pair.Value)
 	}

--- a/sentry/data_source_sentry_key.go
+++ b/sentry/data_source_sentry_key.go
@@ -88,7 +88,7 @@ func dataSourceSentryKeyRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	tflog.Debug(ctx, "Reading Sentry project keys", "org", org, "project", project)
 	keys, resp, err := client.ProjectKeys.List(org, project)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry key read http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/sentry/data_source_sentry_key.go
+++ b/sentry/data_source_sentry_key.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jianyuan/go-sentry/sentry"
+	"github.com/jianyuan/terraform-provider-sentry/logging"
 )
 
 func dataSourceSentryKey() *schema.Resource {
@@ -86,7 +87,8 @@ func dataSourceSentryKeyRead(ctx context.Context, d *schema.ResourceData, meta i
 	project := d.Get("project").(string)
 
 	tflog.Debug(ctx, "Reading Sentry project keys", "org", org, "project", project)
-	keys, _, err := client.ProjectKeys.List(org, project)
+	keys, resp, err := client.ProjectKeys.List(org, project)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/sentry/data_source_sentry_organization.go
+++ b/sentry/data_source_sentry_organization.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jianyuan/go-sentry/sentry"
+	"github.com/jianyuan/terraform-provider-sentry/logging"
 )
 
 func dataSourceSentryOrganization() *schema.Resource {
@@ -37,7 +38,8 @@ func dataSourceSentryOrganizationRead(ctx context.Context, d *schema.ResourceDat
 	slug := d.Get("slug").(string)
 
 	tflog.Debug(ctx, "Reading Sentry org", "orgSlug", slug)
-	org, _, err := client.Organizations.Get(slug)
+	org, resp, err := client.Organizations.Get(slug)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/sentry/data_source_sentry_organization.go
+++ b/sentry/data_source_sentry_organization.go
@@ -39,7 +39,7 @@ func dataSourceSentryOrganizationRead(ctx context.Context, d *schema.ResourceDat
 
 	tflog.Debug(ctx, "Reading Sentry org", "orgSlug", slug)
 	org, resp, err := client.Organizations.Get(slug)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry organisation read http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/sentry/resource_sentry_default_key.go
+++ b/sentry/resource_sentry_default_key.go
@@ -35,7 +35,6 @@ func resourceSentryDefaultKeyCreate(ctx context.Context, d *schema.ResourceData,
 	project := d.Get("project").(string)
 
 	keys, resp, err := client.ProjectKeys.List(org, project)
-	ctx = logging.AttachHttpResponse(ctx, resp)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
@@ -58,12 +57,12 @@ func resourceSentryDefaultKeyCreate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	tflog.Debug(ctx, "Creating Sentry default key", "org", org, "project", project, "keyID", id)
-	_, resp, err = client.ProjectKeys.Update(org, project, id, params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	key, resp, err := client.ProjectKeys.Update(org, project, id, params)
+	tflog.Debug(ctx, "Sentry default key create http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	tflog.Debug(ctx, "Created Sentry default key", "org", org, "project", project, "keyID", id)
+	tflog.Debug(ctx, "Created Sentry default key", "org", org, "project", project, "keyID", key.ID)
 
 	d.SetId(id)
 	return resourceSentryKeyRead(ctx, d, meta)

--- a/sentry/resource_sentry_key.go
+++ b/sentry/resource_sentry_key.go
@@ -123,7 +123,7 @@ func resourceSentryKeyRead(ctx context.Context, d *schema.ResourceData, meta int
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
-	tflog.Trace(ctx, "Read Sentry keys", "keyCount", len(keys), "keys", keys)
+	tflog.Trace(ctx, "Read Sentry keys", "keyCount", len(keys), "keys", logging.TryJsonify(keys))
 
 	found := false
 

--- a/sentry/resource_sentry_key.go
+++ b/sentry/resource_sentry_key.go
@@ -85,7 +85,6 @@ func resourceSentryKeyCreate(ctx context.Context, d *schema.ResourceData, meta i
 	project := d.Get("project").(string)
 
 	_, resp, err := client.Projects.Get(org, project)
-	ctx = logging.AttachHttpResponse(ctx, resp)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.Errorf("project not found \"%v\": %v", project, err)
 	}
@@ -100,7 +99,7 @@ func resourceSentryKeyCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	tflog.Debug(ctx, "Creating Sentry key", "keyName", params.Name, "org", org, "project", project)
 	key, resp, err := client.ProjectKeys.Create(org, project, params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry key create http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -119,7 +118,7 @@ func resourceSentryKeyRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	tflog.Debug(ctx, "Reading Sentry key", "keyID", id, "org", org, "project", project)
 	keys, resp, err := client.ProjectKeys.List(org, project)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry key read http response data", logging.ExtractHttpResponse(resp)...)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
@@ -176,7 +175,7 @@ func resourceSentryKeyUpdate(ctx context.Context, d *schema.ResourceData, meta i
 
 	tflog.Debug(ctx, "Updating Sentry key", "keyID", id)
 	key, resp, err := client.ProjectKeys.Update(org, project, id, params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry key update http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -195,7 +194,7 @@ func resourceSentryKeyDelete(ctx context.Context, d *schema.ResourceData, meta i
 
 	tflog.Debug(ctx, "Deleting Sentry key", "keyID", id)
 	resp, err := client.ProjectKeys.Delete(org, project, id)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry key delete http response data", logging.ExtractHttpResponse(resp)...)
 	tflog.Debug(ctx, "Deleted Sentry key", "keyID", id)
 	return diag.FromErr(err)
 }

--- a/sentry/resource_sentry_organization.go
+++ b/sentry/resource_sentry_organization.go
@@ -52,7 +52,7 @@ func resourceSentryOrganizationCreate(ctx context.Context, d *schema.ResourceDat
 
 	tflog.Debug(ctx, "Creating Sentry organization", "orgName", params.Name)
 	org, resp, err := client.Organizations.Create(params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry organization create http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -69,7 +69,7 @@ func resourceSentryOrganizationRead(ctx context.Context, d *schema.ResourceData,
 
 	tflog.Debug(ctx, "Reading Sentry organization", "orgSlug", slug)
 	org, resp, err := client.Organizations.Get(slug)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry organization read http response data", logging.ExtractHttpResponse(resp)...)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
@@ -93,7 +93,7 @@ func resourceSentryOrganizationUpdate(ctx context.Context, d *schema.ResourceDat
 
 	tflog.Debug(ctx, "Updating Sentry organization", "orgSlug", slug)
 	org, resp, err := client.Organizations.Update(slug, params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry Organization update http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -110,7 +110,7 @@ func resourceSentryOrganizationDelete(ctx context.Context, d *schema.ResourceDat
 
 	tflog.Debug(ctx, "Deleting Sentry organization", "orgSlug", slug)
 	resp, err := client.Organizations.Delete(slug)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry organization delete http response data", logging.ExtractHttpResponse(resp)...)
 	tflog.Debug(ctx, "Deleted Sentry organization", "orgSlug", slug)
 
 	return diag.FromErr(err)

--- a/sentry/resource_sentry_organization.go
+++ b/sentry/resource_sentry_organization.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jianyuan/go-sentry/sentry"
+	"github.com/jianyuan/terraform-provider-sentry/logging"
 )
 
 func resourceSentryOrganization() *schema.Resource {
@@ -50,7 +51,8 @@ func resourceSentryOrganizationCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	tflog.Debug(ctx, "Creating Sentry organization", "orgName", params.Name)
-	org, _, err := client.Organizations.Create(params)
+	org, resp, err := client.Organizations.Create(params)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -67,6 +69,7 @@ func resourceSentryOrganizationRead(ctx context.Context, d *schema.ResourceData,
 
 	tflog.Debug(ctx, "Reading Sentry organization", "orgSlug", slug)
 	org, resp, err := client.Organizations.Get(slug)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
@@ -89,7 +92,8 @@ func resourceSentryOrganizationUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	tflog.Debug(ctx, "Updating Sentry organization", "orgSlug", slug)
-	org, _, err := client.Organizations.Update(slug, params)
+	org, resp, err := client.Organizations.Update(slug, params)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -105,7 +109,8 @@ func resourceSentryOrganizationDelete(ctx context.Context, d *schema.ResourceDat
 	slug := d.Id()
 
 	tflog.Debug(ctx, "Deleting Sentry organization", "orgSlug", slug)
-	_, err := client.Organizations.Delete(slug)
+	resp, err := client.Organizations.Delete(slug)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	tflog.Debug(ctx, "Deleted Sentry organization", "orgSlug", slug)
 
 	return diag.FromErr(err)

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -114,7 +114,7 @@ func resourceSentryProjectCreate(ctx context.Context, d *schema.ResourceData, me
 
 	tflog.Debug(ctx, "Creating Sentry project", "teamName", team, "org", org)
 	proj, resp, err := client.Projects.Create(org, team, params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry project create http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -132,7 +132,7 @@ func resourceSentryProjectRead(ctx context.Context, d *schema.ResourceData, meta
 
 	tflog.Debug(ctx, "Reading Sentry project", "projectSlug", slug, "org", org)
 	proj, resp, err := client.Projects.Get(org, slug)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry project read http response data", logging.ExtractHttpResponse(resp)...)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
@@ -187,7 +187,7 @@ func resourceSentryProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	tflog.Debug(ctx, "Updating Sentry project", "projectSlug", slug, "org", org)
 	proj, resp, err := client.Projects.Update(org, slug, params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry project update http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -205,7 +205,7 @@ func resourceSentryProjectDelete(ctx context.Context, d *schema.ResourceData, me
 
 	tflog.Debug(ctx, "Deleting Sentry project", "projectSlug", slug, "org", org)
 	resp, err := client.Projects.Delete(org, slug)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry project delete http response data", logging.ExtractHttpResponse(resp)...)
 	tflog.Debug(ctx, "Deleted Sentry project", "projectSlug", slug, "org", org)
 
 	return diag.FromErr(err)

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jianyuan/go-sentry/sentry"
+	"github.com/jianyuan/terraform-provider-sentry/logging"
 )
 
 func resourceSentryProject() *schema.Resource {
@@ -112,7 +113,8 @@ func resourceSentryProjectCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	tflog.Debug(ctx, "Creating Sentry project", "teamName", team, "org", org)
-	proj, _, err := client.Projects.Create(org, team, params)
+	proj, resp, err := client.Projects.Create(org, team, params)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -130,6 +132,7 @@ func resourceSentryProjectRead(ctx context.Context, d *schema.ResourceData, meta
 
 	tflog.Debug(ctx, "Reading Sentry project", "projectSlug", slug, "org", org)
 	proj, resp, err := client.Projects.Get(org, slug)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
@@ -183,7 +186,8 @@ func resourceSentryProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	tflog.Debug(ctx, "Updating Sentry project", "projectSlug", slug, "org", org)
-	proj, _, err := client.Projects.Update(org, slug, params)
+	proj, resp, err := client.Projects.Update(org, slug, params)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -200,7 +204,8 @@ func resourceSentryProjectDelete(ctx context.Context, d *schema.ResourceData, me
 	org := d.Get("organization").(string)
 
 	tflog.Debug(ctx, "Deleting Sentry project", "projectSlug", slug, "org", org)
-	_, err := client.Projects.Delete(org, slug)
+	resp, err := client.Projects.Delete(org, slug)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	tflog.Debug(ctx, "Deleted Sentry project", "projectSlug", slug, "org", org)
 
 	return diag.FromErr(err)

--- a/sentry/resource_sentry_project_plugin.go
+++ b/sentry/resource_sentry_project_plugin.go
@@ -54,7 +54,7 @@ func resourceSentryPluginCreate(ctx context.Context, d *schema.ResourceData, met
 
 	tflog.Debug(ctx, "Creating Sentry plugin", "pluginName", plugin, "org", org, "project", project)
 	resp, err := client.ProjectPlugins.Enable(org, project, plugin)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry plugin create http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -64,7 +64,6 @@ func resourceSentryPluginCreate(ctx context.Context, d *schema.ResourceData, met
 
 	params := d.Get("config").(map[string]interface{})
 	_, resp, err = client.ProjectPlugins.Update(org, project, plugin, params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -81,7 +80,7 @@ func resourceSentryPluginRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	tflog.Debug(ctx, "Reading Sentry plugin", "pluginID", id, "org", org, "project", project)
 	plugin, resp, err := client.ProjectPlugins.Get(org, project, id)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry plugin read http response data", logging.ExtractHttpResponse(resp)...)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
@@ -116,7 +115,7 @@ func resourceSentryPluginUpdate(ctx context.Context, d *schema.ResourceData, met
 	tflog.Debug(ctx, "Updating Sentry plugin", "pluginID", id, "org", org, "project", project)
 	params := d.Get("config").(map[string]interface{})
 	plugin, resp, err := client.ProjectPlugins.Update(org, project, id, params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry plugin update http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -134,7 +133,7 @@ func resourceSentryPluginDelete(ctx context.Context, d *schema.ResourceData, met
 
 	tflog.Debug(ctx, "Deleting Sentry plugin", "pluginID", id, "org", org, "project", project)
 	resp, err := client.ProjectPlugins.Disable(org, project, id)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry plugin delete http response data", logging.ExtractHttpResponse(resp)...)
 	tflog.Debug(ctx, "Deleted Sentry plugin", "pluginID", id, "org", org, "project", project)
 
 	return diag.FromErr(err)

--- a/sentry/resource_sentry_project_plugin.go
+++ b/sentry/resource_sentry_project_plugin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jianyuan/go-sentry/sentry"
+	"github.com/jianyuan/terraform-provider-sentry/logging"
 )
 
 func resourceSentryPlugin() *schema.Resource {
@@ -52,7 +53,8 @@ func resourceSentryPluginCreate(ctx context.Context, d *schema.ResourceData, met
 	project := d.Get("project").(string)
 
 	tflog.Debug(ctx, "Creating Sentry plugin", "pluginName", plugin, "org", org, "project", project)
-	_, err := client.ProjectPlugins.Enable(org, project, plugin)
+	resp, err := client.ProjectPlugins.Enable(org, project, plugin)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -61,7 +63,9 @@ func resourceSentryPluginCreate(ctx context.Context, d *schema.ResourceData, met
 	d.SetId(plugin)
 
 	params := d.Get("config").(map[string]interface{})
-	if _, _, err := client.ProjectPlugins.Update(org, project, plugin, params); err != nil {
+	_, resp, err = client.ProjectPlugins.Update(org, project, plugin, params)
+	ctx = logging.AttachHttpResponse(ctx, resp)
+	if err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -77,6 +81,7 @@ func resourceSentryPluginRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	tflog.Debug(ctx, "Reading Sentry plugin", "pluginID", id, "org", org, "project", project)
 	plugin, resp, err := client.ProjectPlugins.Get(org, project, id)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
@@ -110,7 +115,8 @@ func resourceSentryPluginUpdate(ctx context.Context, d *schema.ResourceData, met
 
 	tflog.Debug(ctx, "Updating Sentry plugin", "pluginID", id, "org", org, "project", project)
 	params := d.Get("config").(map[string]interface{})
-	plugin, _, err := client.ProjectPlugins.Update(org, project, id, params)
+	plugin, resp, err := client.ProjectPlugins.Update(org, project, id, params)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -127,7 +133,8 @@ func resourceSentryPluginDelete(ctx context.Context, d *schema.ResourceData, met
 	project := d.Get("project").(string)
 
 	tflog.Debug(ctx, "Deleting Sentry plugin", "pluginID", id, "org", org, "project", project)
-	_, err := client.ProjectPlugins.Disable(org, project, id)
+	resp, err := client.ProjectPlugins.Disable(org, project, id)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	tflog.Debug(ctx, "Deleted Sentry plugin", "pluginID", id, "org", org, "project", project)
 
 	return diag.FromErr(err)

--- a/sentry/resource_sentry_project_rule.go
+++ b/sentry/resource_sentry_project_rule.go
@@ -151,7 +151,7 @@ func resourceSentryRuleCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	tflog.Debug(ctx, "Creating Sentry rule", "ruleName", name, "org", org, "project", project)
 	rule, resp, err := client.Rules.Create(org, project, params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry rule create http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -170,7 +170,7 @@ func resourceSentryRuleRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	tflog.Debug(ctx, "Reading Sentry rule", "ruleID", id, "org", org, "project", project)
 	rules, resp, err := client.Rules.List(org, project)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry rule read http response data", logging.ExtractHttpResponse(resp)...)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
@@ -293,7 +293,7 @@ func resourceSentryRuleUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 	tflog.Debug(ctx, "Updating Sentry rule", "ruleID", id, "org", org, "project", project)
 	rule, resp, err := client.Rules.Update(org, project, id, params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry rule update http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -311,7 +311,7 @@ func resourceSentryRuleDelete(ctx context.Context, d *schema.ResourceData, meta 
 
 	tflog.Debug(ctx, "Deleting Sentry rule", "ruleID", id, "org", org, "project", project)
 	resp, err := client.Rules.Delete(org, project, id)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry rule delete http response data", logging.ExtractHttpResponse(resp)...)
 	tflog.Debug(ctx, "Deleted Sentry rule", "ruleID", id, "org", org, "project", project)
 
 	return diag.FromErr(err)

--- a/sentry/resource_sentry_project_rule.go
+++ b/sentry/resource_sentry_project_rule.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jianyuan/go-sentry/sentry"
+	"github.com/jianyuan/terraform-provider-sentry/logging"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -149,7 +150,8 @@ func resourceSentryRuleCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	tflog.Debug(ctx, "Creating Sentry rule", "ruleName", name, "org", org, "project", project)
-	rule, _, err := client.Rules.Create(org, project, params)
+	rule, resp, err := client.Rules.Create(org, project, params)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -168,6 +170,7 @@ func resourceSentryRuleRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	tflog.Debug(ctx, "Reading Sentry rule", "ruleID", id, "org", org, "project", project)
 	rules, resp, err := client.Rules.List(org, project)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
@@ -289,7 +292,8 @@ func resourceSentryRuleUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	tflog.Debug(ctx, "Updating Sentry rule", "ruleID", id, "org", org, "project", project)
-	rule, _, err := client.Rules.Update(org, project, id, params)
+	rule, resp, err := client.Rules.Update(org, project, id, params)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -306,7 +310,8 @@ func resourceSentryRuleDelete(ctx context.Context, d *schema.ResourceData, meta 
 	project := d.Get("project").(string)
 
 	tflog.Debug(ctx, "Deleting Sentry rule", "ruleID", id, "org", org, "project", project)
-	_, err := client.Rules.Delete(org, project, id)
+	resp, err := client.Rules.Delete(org, project, id)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	tflog.Debug(ctx, "Deleted Sentry rule", "ruleID", id, "org", org, "project", project)
 
 	return diag.FromErr(err)

--- a/sentry/resource_sentry_project_rule.go
+++ b/sentry/resource_sentry_project_rule.go
@@ -174,7 +174,7 @@ func resourceSentryRuleRead(ctx context.Context, d *schema.ResourceData, meta in
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
-	tflog.Trace(ctx, "Read Sentry rules", "ruleCount", len(rules), "rules", rules)
+	tflog.Trace(ctx, "Read Sentry rules", "ruleCount", len(rules), "rules", logging.TryJsonify(rules))
 
 	var rule *sentry.Rule
 	for _, r := range rules {

--- a/sentry/resource_sentry_team.go
+++ b/sentry/resource_sentry_team.go
@@ -68,7 +68,7 @@ func resourceSentryTeamCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	tflog.Debug(ctx, "Creating Sentry team", "teamName", params.Name, "org", org)
 	team, resp, err := client.Teams.Create(org, params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry team create http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -86,7 +86,7 @@ func resourceSentryTeamRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	tflog.Debug(ctx, "Reading Sentry team", "teamSlug", slug, "org", org)
 	team, resp, err := client.Teams.Get(org, slug)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry team read http response data", logging.ExtractHttpResponse(resp)...)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
@@ -115,7 +115,7 @@ func resourceSentryTeamUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 	tflog.Debug(ctx, "Updating Sentry team", "teamSlug", slug, "org", org)
 	team, resp, err := client.Teams.Update(org, slug, params)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry team update http response data", logging.ExtractHttpResponse(resp)...)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -133,7 +133,7 @@ func resourceSentryTeamDelete(ctx context.Context, d *schema.ResourceData, meta 
 
 	tflog.Debug(ctx, "Deleting Sentry team", "teamSlug", slug, "org", org)
 	resp, err := client.Teams.Delete(org, slug)
-	ctx = logging.AttachHttpResponse(ctx, resp)
+	tflog.Debug(ctx, "Sentry team delete http response data", logging.ExtractHttpResponse(resp)...)
 	tflog.Debug(ctx, "Deleted Sentry team", "teamSlug", slug, "org", org)
 
 	return diag.FromErr(err)

--- a/sentry/resource_sentry_team.go
+++ b/sentry/resource_sentry_team.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jianyuan/go-sentry/sentry"
+	"github.com/jianyuan/terraform-provider-sentry/logging"
 )
 
 func resourceSentryTeam() *schema.Resource {
@@ -66,7 +67,8 @@ func resourceSentryTeamCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	tflog.Debug(ctx, "Creating Sentry team", "teamName", params.Name, "org", org)
-	team, _, err := client.Teams.Create(org, params)
+	team, resp, err := client.Teams.Create(org, params)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -84,6 +86,7 @@ func resourceSentryTeamRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	tflog.Debug(ctx, "Reading Sentry team", "teamSlug", slug, "org", org)
 	team, resp, err := client.Teams.Get(org, slug)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if found, err := checkClientGet(resp, err, d); !found {
 		return diag.FromErr(err)
 	}
@@ -111,7 +114,8 @@ func resourceSentryTeamUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	tflog.Debug(ctx, "Updating Sentry team", "teamSlug", slug, "org", org)
-	team, _, err := client.Teams.Update(org, slug, params)
+	team, resp, err := client.Teams.Update(org, slug, params)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -128,7 +132,8 @@ func resourceSentryTeamDelete(ctx context.Context, d *schema.ResourceData, meta 
 	org := d.Get("organization").(string)
 
 	tflog.Debug(ctx, "Deleting Sentry team", "teamSlug", slug, "org", org)
-	_, err := client.Teams.Delete(org, slug)
+	resp, err := client.Teams.Delete(org, slug)
+	ctx = logging.AttachHttpResponse(ctx, resp)
 	tflog.Debug(ctx, "Deleted Sentry team", "teamSlug", slug, "org", org)
 
 	return diag.FromErr(err)


### PR DESCRIPTION
At first I tried to attach to the context part of the `http.Response` object, but this didn't work.

So I simply added a log call to print a subset of the `http.Response` object.

Here's a sample of what the results are:

```log
2022-02-14T20:20:43.624Z debug provider.terraform-provider-sentry_v0.8.0_amd64: Reading Sentry project: tf_resource_type=sentry_project @caller=/local/file/system/terraform-provider-sentry/sentry/resource_sentry_project.go:133 org=coveo tf_req_id=8789851f-38a1-2262-c601-e444792db7ad @module=provider projectSlug=testing-project tf_provider_addr=provider tf_rpc=ReadResource timestamp=2022-02-14T20:20:43.624Z
# looky here! New :tm:
2022-02-14T20:20:43.865Z debug provider.terraform-provider-sentry_v0.8.0_amd64: Sentry project read http response data: requestUrl=https://sentry.private.url.com/api/0/projects/coveo/testing-project/ responseContentType=application/json responseStatus="200 OK" tf_provider_addr=provider tf_rpc=ReadResource @caller=/local/file/system/terraform-provider-sentry/sentry/resource_sentry_project.go:135 @module=provider responseContentLength=29018 tf_req_id=8789851f-38a1-2262-c601-e444792db7ad tf_resource_type=sentry_project timestamp=2022-02-14T20:20:43.865Z
2022-02-14T20:20:43.865Z debug provider.terraform-provider-sentry_v0.8.0_amd64: Read Sentry project: org=coveo projectID=173 projectSlug=testing-project tf_resource_type=sentry_project tf_rpc=ReadResource @caller=/local/file/system/terraform-provider-sentry/sentry/resource_sentry_project.go:139 @module=provider tf_provider_addr=provider tf_req_id=8789851f-38a1-2262-c601-e444792db7ad timestamp=2022-02-14T20:20:43.865Z
```