### PR TITLE
CSEC-18899 bumping goreleaser-action from 3.2 to 3.2 but with hash

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.2.0
+        uses: goreleaser/goreleaser-action@b508e2e3ef3b19d4e4146d4f8fb3ba9db644a757
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
Bumping goreleaser-action from 3.2 to 3.2 via hash to comply with CSEC's GHA policy